### PR TITLE
Only require fog-core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
 rvm:
-  - 2.1.5
+  - 2.3.1

--- a/README.md
+++ b/README.md
@@ -17,11 +17,22 @@ Add this line to your application's Gemfile:
 gem 'refile-fog'
 ```
 
+You also need to add the storage provider you use.
+
+Example for google storage:
+
+```ruby
+gem 'fog-google'
+gem 'google-api-client', '~> 0.8.6'
+
+```
+
 Set up Refile to use the fog backend:
 
 ``` ruby
 # config/initializers/refile.rb
 
+require "fog/google"
 require "refile/fog"
 
 credentials = {

--- a/lib/refile/fog.rb
+++ b/lib/refile/fog.rb
@@ -1,4 +1,6 @@
 require "fog/core"
+require "fog/json"
+require "fog/xml"
 require "refile"
 require "refile/fog/version"
 

--- a/lib/refile/fog.rb
+++ b/lib/refile/fog.rb
@@ -1,4 +1,4 @@
-require "fog"
+require "fog/core"
 require "refile"
 require "refile/fog/version"
 

--- a/refile-fog.gemspec
+++ b/refile-fog.gemspec
@@ -18,5 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "refile"
-  spec.add_dependency "fog-core"
+  spec.add_dependency("fog-core", "~> 1.42")
+  spec.add_dependency("fog-json")
+  spec.add_dependency("fog-xml", "~> 0.1.1")
 end

--- a/refile-fog.gemspec
+++ b/refile-fog.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "refile"
-  spec.add_dependency "fog"
+  spec.add_dependency "fog-core"
 end

--- a/refile-fog.gemspec
+++ b/refile-fog.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency("fog-core", "~> 1.42")
   spec.add_dependency("fog-json")
   spec.add_dependency("fog-xml", "~> 0.1.1")
+  spec.add_development_dependency("fog-aws")
 end

--- a/spec/refile/fog_spec.rb
+++ b/spec/refile/fog_spec.rb
@@ -1,4 +1,5 @@
 require "pry"
+require "fog/aws"
 require "refile/fog"
 require "refile/spec_helper"
 
@@ -21,4 +22,3 @@ RSpec.describe Refile::Fog::Backend do
 
   it_behaves_like :backend
 end
-


### PR DESCRIPTION
To lighten the gem dependencies, I changed the gemspec to only require fog-core, fog-json and fog-xml.

Any providers should be added in the app itself.
